### PR TITLE
Fixed cache issues. Various improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ compile 'com.github.florent37:glidepalette:1.0.5@aar'
 
 ```java
 Glide.with(this).load(url)
-         .listener(GlidePalette.with(url)
+         .listener(new GlidePalette()
                .use(GlidePalette.Profile.MUTED_DARK)
                    .intoBackground(textView)
                    .intoTextColor(textView)
@@ -29,10 +29,10 @@ Glide.with(this).load(url)
 
 ##Initialisation
 
-First, init GlidePalette with an **Url**
+First, init GlidePalette
 
 ```java
-GlidePalette.with(url)
+new GlidePalette()
 ```
 
 ##Palettes

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ compile 'com.github.florent37:glidepalette:1.0.5@aar'
 
 ```java
 Glide.with(this).load(url)
-         .listener(new GlidePalette()
+         .listener(GlidePalette.with(url)
                .use(GlidePalette.Profile.MUTED_DARK)
                    .intoBackground(textView)
                    .intoTextColor(textView)
@@ -29,10 +29,10 @@ Glide.with(this).load(url)
 
 ##Initialisation
 
-First, init GlidePalette
+First, init GlidePalette with an **Url**
 
 ```java
-new GlidePalette()
+GlidePalette.with(url)
 ```
 
 ##Palettes

--- a/glidepalette/src/main/java/com/github/florent37/glidepalette/BitmapPalette.java
+++ b/glidepalette/src/main/java/com/github/florent37/glidepalette/BitmapPalette.java
@@ -31,29 +31,24 @@ public abstract class BitmapPalette {
 
     private LruCache<String, Palette> cache = new LruCache<>(40);
 
-    public static class Profile {
-        public static final int VIBRANT = 0;
-        public static final int VIBRANT_DARK = 1;
-        public static final int VIBRANT_LIGHT = 2;
-        public static final int MUTED = 3;
-        public static final int MUTED_DARK = 4;
-        public static final int MUTED_LIGHT = 5;
-
-        @IntDef({VIBRANT, VIBRANT_DARK, VIBRANT_LIGHT, MUTED, MUTED_DARK, MUTED_LIGHT})
-        @Retention(RetentionPolicy.SOURCE)
-        public @interface PaletteProfile {
-        }
+    @IntDef({Profile.VIBRANT, Profile.VIBRANT_DARK, Profile.VIBRANT_LIGHT,
+            Profile.MUTED, Profile.MUTED_DARK, Profile.MUTED_LIGHT})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface Profile {
+        int VIBRANT = 0;
+        int VIBRANT_DARK = 1;
+        int VIBRANT_LIGHT = 2;
+        int MUTED = 3;
+        int MUTED_DARK = 4;
+        int MUTED_LIGHT = 5;
     }
 
-    public static class Swatch {
-        public static final int RGB = 0;
-        public static final int TITLE_TEXT_COLOR = 1;
-        public static final int BODY_TEXT_COLOR = 2;
-
-        @IntDef({RGB, TITLE_TEXT_COLOR, BODY_TEXT_COLOR})
-        @Retention(RetentionPolicy.SOURCE)
-        public @interface PaletteSwatch {
-        }
+    @IntDef({Swatch.RGB, Swatch.TITLE_TEXT_COLOR, Swatch.BODY_TEXT_COLOR})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface Swatch {
+        int RGB = 0;
+        int TITLE_TEXT_COLOR = 1;
+        int BODY_TEXT_COLOR = 2;
     }
 
     protected BitmapPalette() {
@@ -64,19 +59,19 @@ public abstract class BitmapPalette {
     protected LinkedList<PaletteTarget> targets = new LinkedList<>();
     protected ArrayList<BitmapPalette.CallBack> callbacks = new ArrayList<>();
 
-    public BitmapPalette use(@Profile.PaletteProfile int paletteProfile) {
+    public BitmapPalette use(@Profile int paletteProfile) {
         this.targets.add(new PaletteTarget(paletteProfile));
         return this;
     }
 
-    protected BitmapPalette intoBackground(View view, @Swatch.PaletteSwatch int paletteSwatch) {
+    protected BitmapPalette intoBackground(View view, @Swatch int paletteSwatch) {
         assertTargetsIsNotEmpty();
 
         this.targets.getLast().targetsBackground.add(new Pair<>(view, paletteSwatch));
         return this;
     }
 
-    protected BitmapPalette intoTextColor(TextView textView, @Swatch.PaletteSwatch int paletteSwatch) {
+    protected BitmapPalette intoTextColor(TextView textView, @Swatch int paletteSwatch) {
         assertTargetsIsNotEmpty();
 
         this.targets.getLast().targetsText.add(new Pair<>(textView, paletteSwatch));
@@ -99,7 +94,7 @@ public abstract class BitmapPalette {
 
     private void assertTargetsIsNotEmpty() {
         if (this.targets.isEmpty()) {
-            throw new UnsupportedOperationException("You must specify a palette with use(Profile.PaletteProfile)");
+            throw new UnsupportedOperationException("You must specify a palette with use(Profile.Profile)");
         }
     }
 
@@ -178,7 +173,7 @@ public abstract class BitmapPalette {
         transitionDrawable.startTransition(target.targetCrossfadeSpeed);
     }
 
-    protected static int getColor(Palette.Swatch swatch, @Swatch.PaletteSwatch int paletteSwatch) {
+    protected static int getColor(Palette.Swatch swatch, @Swatch int paletteSwatch) {
         if (swatch != null) {
             switch (paletteSwatch) {
                 case Swatch.RGB:

--- a/glidepalette/src/main/java/com/github/florent37/glidepalette/BitmapPalette.java
+++ b/glidepalette/src/main/java/com/github/florent37/glidepalette/BitmapPalette.java
@@ -52,6 +52,8 @@ public abstract class BitmapPalette {
 
     private static final Map<Bitmap, Palette> CACHE = new WeakHashMap<>();
 
+    protected String url;
+
     protected LinkedList<PaletteTarget> targets = new LinkedList<>();
     protected ArrayList<BitmapPalette.CallBack> callbacks = new ArrayList<>();
 

--- a/glidepalette/src/main/java/com/github/florent37/glidepalette/BitmapPalette.java
+++ b/glidepalette/src/main/java/com/github/florent37/glidepalette/BitmapPalette.java
@@ -29,7 +29,7 @@ public abstract class BitmapPalette {
         void onPaletteLoaded(Palette palette);
     }
 
-    private LruCache<String, Palette> cache = new LruCache<>(40);
+    private static LruCache<String, Palette> cache = new LruCache<>(40);
 
     @IntDef({Profile.VIBRANT, Profile.VIBRANT_DARK, Profile.VIBRANT_LIGHT,
             Profile.MUTED, Profile.MUTED_DARK, Profile.MUTED_LIGHT})

--- a/glidepalette/src/main/java/com/github/florent37/glidepalette/BitmapPalette.java
+++ b/glidepalette/src/main/java/com/github/florent37/glidepalette/BitmapPalette.java
@@ -52,8 +52,6 @@ public abstract class BitmapPalette {
 
     private static final Map<Bitmap, Palette> CACHE = new WeakHashMap<>();
 
-    protected String url;
-
     protected LinkedList<PaletteTarget> targets = new LinkedList<>();
     protected ArrayList<BitmapPalette.CallBack> callbacks = new ArrayList<>();
 

--- a/glidepalette/src/main/java/com/github/florent37/glidepalette/BitmapPalette.java
+++ b/glidepalette/src/main/java/com/github/florent37/glidepalette/BitmapPalette.java
@@ -1,8 +1,6 @@
 package com.github.florent37.glidepalette;
 
 import android.graphics.Bitmap;
-import android.graphics.Canvas;
-import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.TransitionDrawable;
@@ -164,16 +162,12 @@ public abstract class BitmapPalette {
     }
 
     private void crossfadeTargetBackground(PaletteTarget target, Pair<View, Integer> t, int newColor) {
-        final Bitmap next = Bitmap.createBitmap(t.first.getWidth(), t.first.getHeight(), Bitmap.Config.ARGB_8888);
-        final Canvas canvas = new Canvas(next);
-        canvas.drawColor(newColor);
 
         final Drawable oldColor = t.first.getBackground();
-        final BitmapDrawable newBackground = new BitmapDrawable(t.first.getResources(), next);
         final Drawable[] drawables = new Drawable[2];
 
         drawables[0] = oldColor != null ? oldColor : new ColorDrawable(t.first.getSolidColor());
-        drawables[1] = newBackground;
+        drawables[1] = new ColorDrawable(newColor);
         TransitionDrawable transitionDrawable = new TransitionDrawable(drawables);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {

--- a/glidepalette/src/main/java/com/github/florent37/glidepalette/BitmapPalette.java
+++ b/glidepalette/src/main/java/com/github/florent37/glidepalette/BitmapPalette.java
@@ -6,6 +6,7 @@ import android.graphics.drawable.Drawable;
 import android.graphics.drawable.TransitionDrawable;
 import android.os.Build;
 import android.support.annotation.IntDef;
+import android.support.v4.util.LruCache;
 import android.support.v4.util.Pair;
 import android.support.v7.graphics.Palette;
 import android.util.Log;
@@ -16,8 +17,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.LinkedList;
-import java.util.Map;
-import java.util.WeakHashMap;
 
 /**
  * Created by florentchampigny on 16/07/15.
@@ -50,7 +49,7 @@ public abstract class BitmapPalette {
         int BODY_TEXT_COLOR = 2;
     }
 
-    private static final Map<Bitmap, Palette> CACHE = new WeakHashMap<>();
+    private static final LruCache<String, Palette> CACHE = new LruCache<>(40);
 
     protected String url;
 
@@ -199,14 +198,14 @@ public abstract class BitmapPalette {
     }
 
     protected void start(final Bitmap bitmap) {
-        Palette palette = CACHE.get(bitmap);
+        Palette palette = CACHE.get(url);
         if (palette != null) {
             apply(palette, true);
         } else {
             new Palette.Builder(bitmap).generate(new Palette.PaletteAsyncListener() {
                 @Override
                 public void onGenerated(Palette palette) {
-                    CACHE.put(bitmap, palette);
+                    CACHE.put(url, palette);
                     apply(palette, false);
                 }
             });

--- a/glidepalette/src/main/java/com/github/florent37/glidepalette/GlidePalette.java
+++ b/glidepalette/src/main/java/com/github/florent37/glidepalette/GlidePalette.java
@@ -15,13 +15,8 @@ public class GlidePalette<ModelType> extends BitmapPalette implements RequestLis
 
     protected RequestListener<ModelType, GlideDrawable> callback;
 
-    protected GlidePalette() {
-    }
+    public GlidePalette() {
 
-    public static GlidePalette with(String url) {
-        GlidePalette glidePalette = new GlidePalette();
-        glidePalette.url = url;
-        return glidePalette;
     }
 
     public GlidePalette use(@Profile int paletteProfile) {

--- a/glidepalette/src/main/java/com/github/florent37/glidepalette/GlidePalette.java
+++ b/glidepalette/src/main/java/com/github/florent37/glidepalette/GlidePalette.java
@@ -24,7 +24,7 @@ public class GlidePalette<ModelType> extends BitmapPalette implements RequestLis
         return glidePalette;
     }
 
-    public GlidePalette use(@Profile.PaletteProfile int paletteProfile) {
+    public GlidePalette use(@Profile int paletteProfile) {
         super.use(paletteProfile);
         return this;
     }
@@ -33,7 +33,7 @@ public class GlidePalette<ModelType> extends BitmapPalette implements RequestLis
         return this.intoBackground(view, Swatch.RGB);
     }
 
-    public GlidePalette intoBackground(View view, @Swatch.PaletteSwatch int paletteSwatch) {
+    public GlidePalette intoBackground(View view, @Swatch int paletteSwatch) {
         super.intoBackground(view, paletteSwatch);
         return this;
     }
@@ -42,7 +42,7 @@ public class GlidePalette<ModelType> extends BitmapPalette implements RequestLis
         return this.intoTextColor(textView, Swatch.TITLE_TEXT_COLOR);
     }
 
-    public GlidePalette intoTextColor(TextView textView, @Swatch.PaletteSwatch int paletteSwatch) {
+    public GlidePalette intoTextColor(TextView textView, @Swatch int paletteSwatch) {
         super.intoTextColor(textView, paletteSwatch);
         return this;
     }

--- a/glidepalette/src/main/java/com/github/florent37/glidepalette/GlidePalette.java
+++ b/glidepalette/src/main/java/com/github/florent37/glidepalette/GlidePalette.java
@@ -15,8 +15,13 @@ public class GlidePalette<ModelType> extends BitmapPalette implements RequestLis
 
     protected RequestListener<ModelType, GlideDrawable> callback;
 
-    public GlidePalette() {
+    protected GlidePalette() {
+    }
 
+    public static GlidePalette with(String url) {
+        GlidePalette glidePalette = new GlidePalette();
+        glidePalette.url = url;
+        return glidePalette;
     }
 
     public GlidePalette use(@Profile int paletteProfile) {

--- a/glidepalette/src/main/java/com/github/florent37/glidepalette/PaletteTarget.java
+++ b/glidepalette/src/main/java/com/github/florent37/glidepalette/PaletteTarget.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
  */
 public class PaletteTarget {
 
-    @BitmapPalette.Profile.PaletteProfile
+    @BitmapPalette.Profile
     protected int paletteProfile = GlidePalette.Profile.VIBRANT;
 
     protected ArrayList<Pair<View, Integer>> targetsBackground = new ArrayList<>();
@@ -21,7 +21,7 @@ public class PaletteTarget {
     protected int targetCrossfadeSpeed = DEFAULT_CROSSFADE_SPEED;
     protected static final int DEFAULT_CROSSFADE_SPEED = 300;
 
-    public PaletteTarget(@BitmapPalette.Profile.PaletteProfile int paletteProfile) {
+    public PaletteTarget(@BitmapPalette.Profile int paletteProfile) {
         this.paletteProfile = paletteProfile;
     }
 


### PR DESCRIPTION
Fixes #7 
- The cache is now static, which means it's not recreated on every new GlidePalette.with() call.
- Don't nest IntDef inside another class.. (minor code refactoring)
- Don't crossfade the Palette colors if we're coming from a cache hit. The assumption is that the colors have already been set, so we would be crossfading for no reason.
- Use a ColorDrawable instead of a Bitmap for the TransitionDrawable of the crossfade.
