### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ GlidePalette
 
 ![Alt sample](https://raw.githubusercontent.com/florent37/GlidePalette/master/screenshot/night_small_2.png)
 
-#Download
+# Download
 
 In your module [![Download](https://api.bintray.com/packages/florent37/maven/GlidePalette/images/download.svg)](https://bintray.com/florent37/maven/GlidePalette/_latestVersion)
 ```groovy
@@ -12,7 +12,7 @@ compile 'com.github.florent37:glidepalette:2.0.1'
 compile 'com.github.bumptech.glide:glide:4.0.0-SNAPSHOT'
 ```
 
-#Sample
+# Sample
 
 ```java
 Glide.with(this).load(url)
@@ -29,7 +29,7 @@ Glide.with(this).load(url)
          .into(imageView);
 ```
 
-##Initialisation
+## Initialisation
 
 First, init GlidePalette with an **Url**
 
@@ -37,7 +37,7 @@ First, init GlidePalette with an **Url**
 GlidePalette.with(url)
 ```
 
-##Palettes
+## Palettes
 
 You can successively use following Palettes :
 
@@ -61,7 +61,7 @@ You can successively use following Palettes :
     //next operations will use Profile.VIBRANT
 ```
 
-##Swatches
+## Swatches
 
 With the following Swatches
 
@@ -69,7 +69,7 @@ With the following Swatches
 - TITLE_TEXT_COLOR
 - BODY_TEXT_COLOR
 
-##Targets
+## Targets
 
 Into Backgrounds
 
@@ -93,7 +93,7 @@ with optional Background Crossfade effect
     // specify own crossfade speed in ms
 ```
 
-#CallBack
+# CallBack
 
 Or simply return into CallBack
 
@@ -108,17 +108,17 @@ Or simply return into CallBack
 ```
 
 
-#TODO
+# TODO
 
-#Community
+# Community
 
 Looking for contributors, feel free to fork !
 
-#Dependencies
+# Dependencies
 
 - Glide from Bumptech : [https://github.com/bumptech/glide][glide]
 
-#Credits
+# Credits
 
 Author: Florent Champigny www.florentchampigny.com/
 
@@ -135,7 +135,7 @@ Author: Florent Champigny www.florentchampigny.com/
        src="https://raw.githubusercontent.com/florent37/DaVinci/master/mobile/src/main/res/drawable-hdpi/linkedin.png" />
 </a>
 
-#License
+# License
 
     Copyright 2015 florent37, Inc.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
