### PR TITLE
Add-nullchecks-to-PaletteAsyncListener

### DIFF
--- a/glidepalette/src/main/java/com/github/florent37/glidepalette/BitmapPalette.java
+++ b/glidepalette/src/main/java/com/github/florent37/glidepalette/BitmapPalette.java
@@ -232,7 +232,7 @@ public abstract class BitmapPalette {
         builder.generate(new Palette.PaletteAsyncListener() {
             @Override
             public void onGenerated(Palette palette) {
-                if (!skipCache) {
+                if (!skipCache && url != null && palette != null) {
                     CACHE.put(url, palette);
                 }
                 apply(palette, false);


### PR DESCRIPTION
Added this after getting the following crash: 

```
Fatal Exception: java.lang.NullPointerExceptionkey == null || value == null Raw Text
--
android.support.v4.util.LruCache.put (LruCache.java:139)
com.github.florent37.glidepalette.BitmapPalette$1.onGenerated (BitmapPalette.java:236)
```